### PR TITLE
Additional output format/filtering

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+### 1.0.31
+
+* additional output format and filters for "Classic" endpoint
+
 ### 1.0.30
 
 * remove dependency on astroquery

--- a/object_service/NED.py
+++ b/object_service/NED.py
@@ -163,6 +163,14 @@ def get_NED_refcodes(obj_data):
     # Did we get a time range for filtering?
     q += ' year:{0}'.format(obj_data.get('start_year', 1800))
     q += '-{0}'.format(obj_data.get('end_year', datetime.datetime.now().year))
+    # Did we get a bibstem filter?
+    if obj_data.has_key('journals'):
+        jrnl_list = " OR ".join(map(lambda a: "%s" % a, obj_data['journals']))
+        q += ' bibstem:({0})'.format(jrnl_list)
+    # Do we want refereed publications only?
+    if obj_data.has_key('refereed_status'):
+        q += ' property:{0}'.format(obj_data['refereed_status'])
+    print q
     # Get the information from Solr
     headers = {'X-Forwarded-Authorization': request.headers.get('Authorization')}
     params = {'wt': 'json', 'q': q, 'fl': 'bibcode',

--- a/object_service/views.py
+++ b/object_service/views.py
@@ -209,9 +209,18 @@ class ClassicObjectSearch(Resource):
         results = get_NED_refcodes(request.json)
 
         if "Error" in results:
-                    current_app.logger.error('Classic Object Search request request blew up')
-                    return results, 500
+            current_app.logger.error('Classic Object Search request request blew up')
+            return results, 500
         duration = time.time() - stime
         current_app.logger.info('Classic Object Search request successfully completed in %s real seconds'%duration)
-        return results
+        # what output format?
+        try:
+            oformat = request.json['output_format']
+        except:
+            oformat = 'json'
+        # send the results back in the requested format
+        if oformat == 'json':
+            return results
+        else:
+            return "\n".join(results['data'])
             


### PR DESCRIPTION
For replacement of the "nedsrv" call, output of just an ASCII list of bibcodes has been implemented and some filtering options have been added (bibstems and refereed status)