### PR TITLE
correct mime-type for ASCII. filter by month

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+### 1.0.32
+
+* Fix of mime-type for ASCII output. Add filtering by month.
+
 ### 1.0.31
 
 * additional output format and filters for "Classic" endpoint

--- a/object_service/NED.py
+++ b/object_service/NED.py
@@ -160,9 +160,14 @@ def get_NED_refcodes(obj_data):
     # with spaces replaced by underscores)
     obj_list = " OR ".join(map(lambda a: "nedid:%s" % a.replace(' ','_'), canonicals))
     q = '%s' % obj_list
-    # Did we get a time range for filtering?
-    q += ' year:{0}'.format(obj_data.get('start_year', 1800))
-    q += '-{0}'.format(obj_data.get('end_year', datetime.datetime.now().year))
+    # Format the date range for filtering: pubdate:[YYYY-MM TO YYYY-MM]
+    date_range = "[{0}-{1} TO {2}-{3}]".format(
+        obj_data.get('start_year', str(1800)),
+        obj_data.get('start_month', "00"),
+        obj_data.get('end_year', str(datetime.datetime.now().year)),
+        obj_data.get('end_month', "00"),
+    )
+    q += ' pubdate:{0}'.format(date_range)
     # Did we get a bibstem filter?
     if obj_data.has_key('journals'):
         jrnl_list = " OR ".join(map(lambda a: "%s" % a, obj_data['journals']))
@@ -170,7 +175,6 @@ def get_NED_refcodes(obj_data):
     # Do we want refereed publications only?
     if obj_data.has_key('refereed_status'):
         q += ' property:{0}'.format(obj_data['refereed_status'])
-    print q
     # Get the information from Solr
     headers = {'X-Forwarded-Authorization': request.headers.get('Authorization')}
     params = {'wt': 'json', 'q': q, 'fl': 'bibcode',

--- a/object_service/views.py
+++ b/object_service/views.py
@@ -1,6 +1,7 @@
 from flask import current_app, request
 from flask_restful import Resource
 from flask_discoverer import advertise
+from flask import Response
 from SIMBAD import get_simbad_data
 from SIMBAD import do_position_query
 from SIMBAD import parse_position_string
@@ -222,5 +223,6 @@ class ClassicObjectSearch(Resource):
         if oformat == 'json':
             return results
         else:
-            return "\n".join(results['data'])
+            output = "\n".join(results['data'])
+            return Response(output, mimetype='text/plain; charset=us-ascii')
             


### PR DESCRIPTION
* Asking for `classic` output now returns a list of bibcodes using the correct mim-type
* Filtering by month is now supported (`pubdate:[YYYY-MM TO YYYY-MM]`)