### PR TITLE
Bugfix: get correct data from NED response

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+### 1.0.34
+
+* Bugfix for nedsrv endpoint
+
 ### 1.0.33
 
 * Endpoint 'classic' renamed to 'nedsrv'

--- a/object_service/NED.py
+++ b/object_service/NED.py
@@ -152,7 +152,7 @@ def get_NED_refcodes(obj_data):
         # We have a canonical name. Store it in the appropriate list, so that we can query Solr with
         # it and retrieve bibcodes
             try:
-                canonicals.append(ned_data['Interpreted']['Name'])
+                canonicals.append(ned_data['Preferred']['Name'])
             except:
                 # This should not happen, because result codes 3 are supposed to have the canonical name
                 continue


### PR DESCRIPTION
From NED response 'Preferred' has the canonical object name, rather than 'Interpreted'!