### PR TITLE
bugfix

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+### 1.0.46
+
+* bugfix in returned data processing
+
 ### 1.0.45
 
 * Update of HTTP status codes for nedsrv errors

--- a/object_service/utils.py
+++ b/object_service/utils.py
@@ -123,10 +123,12 @@ def get_object_translations(onames, trgts):
                 # An error was returned!
                 current_app.logger.error('Failed to find data for {0} object {1}!: {2}'.format(trgt.upper(), oname, result.get('Error Info','NA')))
                 continue
+            try:
+                # We need to have a 'try' here in case a service returns an empty 'data' attribute
+                idmap[trgt][oname] =[e.get('id',0) for e in result['data'].values()][0]
+            except:
+                continue
 
-            idmap[trgt][oname] =[e.get('id',0) for e in result['data'].values()][0]
-
-            
     return idmap
 
 def translate_query(solr_query, oqueries, trgts, onames, translations):


### PR DESCRIPTION
The function `get_object_translations` got an exception when e.g. NED did not return data and the results had an empty `data` attribute. This was removed in the previous commit because I erroneously believed this check was superfluous!