### PR TITLE
no synonym replacement for abs: query

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
+### 1.0.61
+
+* Switched off synonym replacement for ADS metadata search
+
 ### 1.0.60
 
-* Iproved coverage of unittests
+* Improved coverage of unittests
 
 ### 1.0.59
 

--- a/object_service/tests/test_endpoints.py
+++ b/object_service/tests/test_endpoints.py
@@ -349,7 +349,7 @@ class TestExpectedResults(TestCase):
             data=json.dumps({'query': query}))
         # The response should have a status code 200
         # See if we received the expected results
-        expected = {'query': 'bibstem:A&A ((abs:Andromeda OR simbid:1575544 OR nedid:Andromeda) database:astronomy) year:2015'}
+        expected = {'query': 'bibstem:A&A ((=abs:Andromeda OR simbid:1575544 OR nedid:Andromeda) database:astronomy) year:2015'}
         self.assertEqual(r.json, expected)
 
     @httpretty.activate
@@ -386,7 +386,7 @@ class TestExpectedResults(TestCase):
             data=json.dumps({'query': query}))
         # The response should have a status code 200
         # See if we received the expected results
-        expected = {'query': 'bibstem:A&A ((abs:Andromeda OR simbid:1575544 OR nedid:Andromeda) database:astronomy) year:2015'}
+        expected = {'query': 'bibstem:A&A ((=abs:Andromeda OR simbid:1575544 OR nedid:Andromeda) database:astronomy) year:2015'}
         self.assertEqual(r.json, expected)
 
     def test_object_search_empty_query(self):

--- a/object_service/tests/test_internals_nedsrv.py
+++ b/object_service/tests/test_internals_nedsrv.py
@@ -10,6 +10,9 @@ import time
 from object_service import app
 import json
 import httpretty
+import datetime
+
+now = datetime.datetime.now()
 
 
 class TestDataRetrieval(TestCase):
@@ -329,7 +332,7 @@ class TestDataRetrieval(TestCase):
         # Now run the query
         result = get_NED_refcodes(obj_data)
         expected = {"Error": "Unable to get results!", 
-                    "Error Info": "No bibcodes returned for query: nedid:FOO_BAR year:1800-2018 bibstem:(ApJ OR A&A) property:refereed"}
+                    "Error Info": "No bibcodes returned for query: nedid:FOO_BAR year:1800-%s bibstem:(ApJ OR A&A) property:refereed"%now.year}
         self.assertEqual(result, expected) 
     
     @httpretty.activate

--- a/object_service/tests/test_queries.py
+++ b/object_service/tests/test_queries.py
@@ -30,7 +30,7 @@ class TestQueryStringParsing(TestCase):
             'object:Foo OR object:Bar':[['Foo', 'Bar'],['object:Foo','object:Bar']],
             'object:("Foo Bar" OR Something)':[['Foo Bar', 'Something'],['object:("Foo Bar" OR Something)']],
             'mod1:bar object:(Bla OR Something) mod2:foo object:(X OR Y)':[['Bla', 'Something', 'X', 'Y'],['object:(Bla OR Something)', 'object:(X OR Y)']],
-            'citations(reviews(popular(object:("M 1" OR M81) OR abs:Andromeda))) year:2010 property:refereed': [['M 1', 'M81'],['object:("M 1" OR M81)']],
+            'citations(reviews(popular(object:("M 1" OR M81) OR =abs:Andromeda))) year:2010 property:refereed': [['M 1', 'M81'],['object:("M 1" OR M81)']],
             }
 
         for qstring, expected in test_cases.items():
@@ -51,9 +51,9 @@ class TestQueryStringParsing(TestCase):
         }
         
         test_cases = {
-            'object:X':'((abs:X OR simbid:123 OR nedid:XXX) database:astronomy)',
-            'object:(X OR Y)':'((abs:(X OR Y) OR simbid:(123 OR 456) OR nedid:(XXX OR YYY)) database:astronomy)',
-            'citations(object:(X OR Y) OR fulltext:X) -foo:bar object:Z':'citations(((abs:(X OR Y) OR simbid:(123 OR 456) OR nedid:(XXX OR YYY)) database:astronomy) OR fulltext:X) -foo:bar ((abs:Z OR simbid:789 OR nedid:0) database:astronomy)'
+            'object:X':'((=abs:X OR simbid:123 OR nedid:XXX) database:astronomy)',
+            'object:(X OR Y)':'((=abs:(X OR Y) OR simbid:(123 OR 456) OR nedid:(XXX OR YYY)) database:astronomy)',
+            'citations(object:(X OR Y) OR fulltext:X) -foo:bar object:Z':'citations(((=abs:(X OR Y) OR simbid:(123 OR 456) OR nedid:(XXX OR YYY)) database:astronomy) OR fulltext:X) -foo:bar ((=abs:Z OR simbid:789 OR nedid:0) database:astronomy)'
         }
         
         for qstring, expected in test_cases.items():

--- a/object_service/utils.py
+++ b/object_service/utils.py
@@ -135,20 +135,20 @@ def get_object_translations(onames, trgts):
 def translate_query(solr_query, oqueries, trgts, onames, translations):
     # The goal is to translate the original Solr query with the embedded
     # "object:" queries into a Solr query with actual Solr fields
-    # (nedid:, simbid:) and to include an "abs:" query to simulate the
+    # (nedid:, simbid:) and to include an "=abs:" query to simulate the
     # "ADS Objects" search from ADS Classic. The following will be the general patterns
     # a. single object name:
-    #      object:Andromeda    --> (simbid:translations['simbid'].get("Andromeda","0") OR nedid:translations['nedid'].get("Andromeda","0") OR abs:"Andromeda") database:astronomy
+    #      object:Andromeda    --> (simbid:translations['simbid'].get("Andromeda","0") OR nedid:translations['nedid'].get("Andromeda","0") OR =abs:"Andromeda") database:astronomy
     # b. object name as phrase
     #      object:"Large Magellanic Cloud"  --> same idea as under a.
     # c. object query as expression
     #      object:(Boolean expression) like object:(("51 Peg b" OR 16CygB) AND Osiris) -->
-    #      (simbid:(boolean expression of simbid translations) OR nedid:(boolean expression of nedid translations) OR abs:(original boolean)) database:astronomy
+    #      (simbid:(boolean expression of simbid translations) OR nedid:(boolean expression of nedid translations) OR =abs:(original boolean)) database:astronomy
     # The approach is then
     # For each of the N object query components O_i (i=1,...,N) parsed out of the original Solr query S, create their translated equivalent
     # T_i (i=1,...,N) and do a replacement S.replace(O_i, T_i)
     for oquery in oqueries:
-        query_components = [oquery.replace('object:','abs:')]
+        query_components = [oquery.replace('object:','=abs:')]
         simbad_query = oquery.replace('object:','simbid:')
         ned_query    = oquery.replace('object:','nedid:')
         for oname in onames:


### PR DESCRIPTION
`=abs:(...)` instead of `abs:(...)` for the metadata search part of the query