### PR TITLE
Fix for caret bug

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+### 1.0.65
+
+* Fix bug when there is a caret in the query string
+
 ### 1.0.64
 
 * Better error handling for failed cone search

--- a/object_service/views.py
+++ b/object_service/views.py
@@ -138,7 +138,7 @@ class QuerySearch(Resource):
             targets = ['simbad', 'ned']
         # Get the object names and individual object queries from the Solr query
         try:
-            object_names, object_queries = parse_query_string(solr_query)
+            object_names, object_queries = parse_query_string(solr_query.replace('^',''))
         except Exception, err:
             current_app.logger.error('Parsing the identifiers out of the query string blew up!')
             return {"Error": "Unable to get results!",


### PR DESCRIPTION
The query `^author year object:"foo"` failed. This fixes this problem.